### PR TITLE
Fixed issue with tags in hebrew

### DIFF
--- a/widgets/checkbox-filter.php
+++ b/widgets/checkbox-filter.php
@@ -324,9 +324,10 @@ class Checkbox_Filter extends \Elementor\Widget_Base {
         }
 
         foreach ($terms as $k => $v) {
+          	$slug = (preg_match("/\p{Hebrew}/u", urldecode($v->slug))?$v->term_id : $v->slug);
             $li[] = '<li
             class="cat-checkbox-filter"
-            data-term="'.$jsTax."-".$v->slug.'"
+            data-term="'.$jsTax."-".$slug.'"
             data-container="'.$filtererId.'"
             data-posts="'.$settings['post_id'].'">
             <span class="cat-checkbox-icon-container">'.$icon.'</span>

--- a/widgets/dropdown-filter.php
+++ b/widgets/dropdown-filter.php
@@ -184,9 +184,10 @@ class Dropdown_Filter extends \Elementor\Widget_Base {
         '. __($select_text, 'elementor-super-cat').'
         </option>';
         foreach ($terms as $k => $v) {
+          	$slug = (preg_match("/\p{Hebrew}/u", urldecode($v->slug))?$v->term_id : $v->slug);
             $li[] = '<option
             class="cat-dropdown-filter"
-            data-term="'.$jsTax."-".$v->slug.'"
+            data-term="'.$jsTax."-".$slug.'"
             data-container="'.$filtererId.'"
             data-posts="'.$settings['post_id'].'">
             '.$v->name.'

--- a/widgets/post-filter.php
+++ b/widgets/post-filter.php
@@ -239,6 +239,7 @@ class Post_Filter extends \Elementor\Widget_Base {
     }
 
 
+
     /**
     * Render the widget output on the frontend.
     *
@@ -278,9 +279,11 @@ class Post_Filter extends \Elementor\Widget_Base {
         '. __($settings['all_text'], 'elementor-super-cat').'
         </li>';
         foreach ($terms as $k => $v) {
+
+          	$slug = (preg_match("/\p{Hebrew}/u", urldecode($v->slug))?$v->term_id : $v->slug);
             $li[] = '<li
             class="super-cat-post-filter elementor-portfolio__filter"
-            data-term="'.$jsTax."-".$v->slug.'"
+            data-term="'.$jsTax."-".$slug .'"
             data-container="'.$filtererId.'"
             data-posts="'.$settings['post_id'].'">
             '.$v->name.'


### PR DESCRIPTION
I noticed that if the taxonomy is in Hebrew the slug is url encoded and the attributes on the posts are the term_id rather then the slug.
So I added a check before the creation of the "data-term" => ( if the slug is in Hebrew) 
 value= term_id.